### PR TITLE
fix(specification): apply fix for multiple anchors

### DIFF
--- a/src/specification.js
+++ b/src/specification.js
@@ -247,12 +247,14 @@ function build(options) {
           yamlDocsReady.push(readyDocument);
           errsToDelete.push(index);
         }
-
-        // Cleanup solved errors in order to allow for parser to pass through.
-        for (const errIndex of errsToDelete) {
-          docWithErr.errors.splice(errIndex, 1);
-        }
       });
+      // reverse sort the deletion array so we always delete from the end
+      errsToDelete.sort((a, b) => b - a);
+
+      // Cleanup solved errors in order to allow for parser to pass through.
+      for (const errIndex of errsToDelete) {
+        docWithErr.errors.splice(errIndex, 1);
+      }
     }
 
     const errReport = yamlDocsErrors


### PR DESCRIPTION
Adjusted the when the delete of the error array happens so everything gets deleted after processing.  Also ensured deletes happen from the back of the array to fix any potential array re-ordering issues that may arrise.

Fix  Issue #252
https://github.com/Surnet/swagger-jsdoc/issues/252